### PR TITLE
Add missing $arch to Germany mirrors making it 404

### DIFF
--- a/mirrorlist.arch4edu
+++ b/mirrorlist.arch4edu
@@ -20,9 +20,9 @@
 
 ## Germany
 #### By Felix Kopp
-#Server = https://mirror.autisten.club/arch4edu
+#Server = https://mirror.autisten.club/arch4edu/$arch
 #### By Jeremy Kescher
-#Server = https://arch4edu.mirror.kescher.at
+#Server = https://arch4edu.mirror.kescher.at/$arch
 
 ## United States
 #### Keybase


### PR DESCRIPTION
The new German mirrors was missing `$arch`, in result it 404 when pacman want to refresh from those servers.

Signed-off-by: Gontier Julien <gontierjulien68@gmail.com>