### PR TITLE
Update mirrorlist.arch4edu

### DIFF
--- a/mirrorlist.arch4edu
+++ b/mirrorlist.arch4edu
@@ -19,8 +19,8 @@
 #Server = https://mirror.lesviallon.fr/arch4edu/$arch
 
 ## Germany
-#### By Felix Kopp
-#Server = https://mirror.autisten.club/arch4edu/$arch
+#### By Fef
+#Server = https://pkg.fef.moe/arch4edu/$arch
 #### By Jeremy Kescher
 #Server = https://arch4edu.mirror.kescher.at/$arch
 


### PR DESCRIPTION
Change name and URL of a mirror to reflect some changes.

(I am not the person, however, please try actually accessing the old URL and see where it redirects you. It has been like this for quite a while now. Also, that mirror is syncing off of mine anyway)

Also: Closes #3