### PR TITLE
Add Austrian mirror, change German mirror URL, French -> France

### DIFF
--- a/mirrorlist.arch4edu
+++ b/mirrorlist.arch4edu
@@ -14,7 +14,11 @@
 #### Yunnan University
 #Server = https://mirrors.ynu.edu.cn/arch4edu/$arch
 
-## French
+## Austria
+#### By Jeremy Kescher
+#Server = https://at.arch4edu.mirror.kescher.at/$arch
+
+## France
 #### By Antoine Viallon
 #Server = https://mirror.lesviallon.fr/arch4edu/$arch
 
@@ -22,7 +26,7 @@
 #### By Fef
 #Server = https://pkg.fef.moe/arch4edu/$arch
 #### By Jeremy Kescher
-#Server = https://arch4edu.mirror.kescher.at/$arch
+#Server = https://de.arch4edu.mirror.kescher.at/$arch
 
 ## United States
 #### Keybase


### PR DESCRIPTION
I've added an Austrian mirror (and as such, made a slight change to my old mirror URL - that one will keep working for the foreseeable future, but might break at some point).

I've also corrected "French", which is referring to a language, to "France", which reflects the country mirror.lesviallon.fr is hosted in.

I've added the
```
## Austria
```
section below the section of China, even though that does not preserve alphabetical order, since the source mirror should perhaps be at the very top, in my opinion. If you disagree, you may simply change this after merging my PR.